### PR TITLE
Bug fix on resolve function

### DIFF
--- a/src/addPlugin.js
+++ b/src/addPlugin.js
@@ -20,7 +20,7 @@ export function downloadFile(args) {
             const file = path.join(directory , fileName)
             
             fs.outputFileSync(file, body)
-            resolve(body);
+            resolve('downloadFile ' + file + ' downloaded');
         });
     });
 }


### PR DESCRIPTION
In case of large file files switching body to the resolve function generates an interruption of the script. 
In case of really large files it also generates an out of memory.

I think this is caused by the fact that resolve turns body into a string and then loads all the contents into memory but I'm not sure. 

From what I've seen at resolve function would be enough pass a static string but just to be sure I put a dynamic string with the path of the downloaded file. 

This modification has been tested by downloading multiple files remotely even 500MB and it worked without problems.