### PR TITLE
BUGFIX : Syntax Error in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
          on('task', {downloadFile})
-      })
+      }
     }
-  }
 })
 ```
 


### PR DESCRIPTION
This pull request addresses the issue   : BUG : Syntax error under Installation :For Cypress 10 and above #33

Changes made:
- Fixed the syntax error in the README file by correcting the code example.

Please review and merge. Thank you!
