### PR TITLE
feat: Added timeout param to possibility to download large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,24 @@ cy.downloadFile('https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg','my
 cy.downloadFile('https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg','mydownloads','example.jpg','MyCustomAgentName')
 ```
 
-## Example of using timeout
+## Example of command with a timeout
 ```javascript
 cy.downloadFile('https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg','mydownloads','example.jpg', "MyCustomAgentName", { timeout: 600000 })
 ```
+
+## Parameters
+
+Here are the parameters for the `cy.downloadFile` command:
+
+| Parameter         | Type     | Description                                                            |
+|-------------------|----------|------------------------------------------------------------------------|
+| `url`             | string   | The URL of the file to be downloaded.                                  |
+| `directory`       | string   | The directory where the file will be saved.                           |
+| `filename`        | string   | (Optional) The name of the downloaded file. If not provided, the filename will be extracted from the URL. |
+| `userAgent`       | string   | (Optional) Custom user-agent string for the download request.         |
+| `options`         | object   | (Optional) An object containing additional options.                    |
+| `options.timeout` | number   | (Optional) Timeout value (in milliseconds) for the download operation.|
+
+
 ## Version 1.2.0
 Because request is deprecated we changed to cross-fetch. This works on Cypress 3.8.0 and upwards. If you notice problems please let me know

--- a/README.md
+++ b/README.md
@@ -65,5 +65,10 @@ cy.downloadFile('https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg','my
 ```javascript
 cy.downloadFile('https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg','mydownloads','example.jpg','MyCustomAgentName')
 ```
+
+## Example of using timeout
+```javascript
+cy.downloadFile('https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg','mydownloads','example.jpg', "MyCustomAgentName", { timeout: 600000 })
+```
 ## Version 1.2.0
 Because request is deprecated we changed to cross-fetch. This works on Cypress 3.8.0 and upwards. If you notice problems please let me know

--- a/cypress/integration/test-plugin/download-files.spec.js
+++ b/cypress/integration/test-plugin/download-files.spec.js
@@ -1,8 +1,16 @@
 /// <reference types="cypress" />
 
 describe('Cypress Downloadfile Testing', () => {
+    it('Large Size file', () => {
+        cy.downloadFile(
+            'http://212.183.159.230/512MB.zip',
+            'mydownloads',
+            '512MB.zip',
+            "MyAgent",
+            { timeout: 600000 }
+        )
+    })
     it('Medium Size file', () => {
-        cy.visit('http://proof.ovh.net/files/')
         cy.downloadFile(
             'https://proof.ovh.net/files/100Mb.dat',
             'mydownloads',

--- a/src/downloadFileCommand.js
+++ b/src/downloadFileCommand.js
@@ -1,4 +1,4 @@
-Cypress.Commands.add('downloadFile', (url, dir, fileName, userAgent) => {
+Cypress.Commands.add('downloadFile', (url, dir, fileName, userAgent, { timeout } = {}) => {
     return cy.getCookies().then(cookies => {
         return cy.task('downloadFile', {
             url: url,
@@ -6,6 +6,6 @@ Cypress.Commands.add('downloadFile', (url, dir, fileName, userAgent) => {
             cookies: cookies,
             fileName: fileName,
             userAgent: userAgent,
-        })
+        }, { timeout })
     })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,10 +3,22 @@
 declare namespace Cypress {
     interface Chainable<Subject> {
       /**
-       * Create several Todo items via UI
+       * This command allows you to download a file from a given URL and save it to a specified directory with an optional filename.
+       * @param url The url to download the file from
+       * @param directory The directory to save the file to
+       * @param filename The filename to save the file as
+       * @param userAgent Header to use for the request
+       * @param timeout The timeout for the request
        * @example
-       * cy.downloadFile('http://demourl','example','demo.pdf')
+       * Basic usage
+       * cy.downloadFile('http://demourl', 'example', 'demo.pdf')
+       * 
+       * With a custom user agent
+       * cy.downloadFile('http://demourl', 'example', 'demo.pdf', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36')
+       * 
+       * With a custom timeout
+       * cy.downloadFile('http://demourl', 'example', 'demo.pdf', '', {timeout: 10000})
        */
-      downloadFile(url: string, directory: string, filename:string, userAgent?:string): Chainable<any>
+      downloadFile(url: string, directory: string, filename:string, userAgent?:string, options?: { timeout: number }): Chainable<any>
     }
   }


### PR DESCRIPTION
Added the possibility to set a timeout for the download function. It is helpful for those who want to download files that size is over 100-200 Mb

Updated JSdoc for `downloadFile` in `types/index.d.ts` file

Updated README.md file and added Parameters section with params description [See more ...](https://github.com/PeaceDate/cypress-downloadfile/tree/add_timeout_for_large_downloads#parameters)